### PR TITLE
Implement product-alerts test; all others fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 `npm install`
 
-# Local Development
+## Local Development
 
 `ng serve`
 http://localhost:4200
 
-## Auto generate component directory and placeholder files
+### Testing
+
+Full suite: `ng test`
+Single file: `ng test --include="<relative-path>"`
+
+### Auto generate component directory and placeholder files
 
 `ng generate component <name>`
 

--- a/angular.json
+++ b/angular.json
@@ -3,8 +3,13 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "angular.io-example": {
+    "angular-test": {
       "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss"
+        }
+      },
       "root": "",
       "sourceRoot": "src",
       "prefix": "app",
@@ -12,17 +17,20 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist",
+            "outputPath": "dist/angular-test",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
               "src/assets"
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.scss"
             ],
             "scripts": []
           },
@@ -57,10 +65,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "angular.io-example:build:production"
+              "browserTarget": "angular-test:build:production"
             },
             "development": {
-              "browserTarget": "angular.io-example:build:development"
+              "browserTarget": "angular-test:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -68,14 +76,18 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "angular.io-example:build"
+            "browserTarget": "angular-test:build"
           }
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "tsconfig.spec.json",
+            "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
               "src/assets"
@@ -85,23 +97,8 @@
             ],
             "scripts": []
           }
-        },
-        "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
-          "options": {
-            "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "angular.io-example:serve"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "angular.io-example:serve:production"
-            }
-          }
         }
       }
     }
-  },
-  "cli": {
-    "analytics": false
   }
 }

--- a/src/app/product-alerts/product-alerts.component.spec.ts
+++ b/src/app/product-alerts/product-alerts.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProductAlertsComponent } from './product-alerts.component';
+
+describe('ProductAlertsComponent', () => {
+  let component: ProductAlertsComponent;
+  let fixture: ComponentFixture<ProductAlertsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ProductAlertsComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProductAlertsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,21 +10,5 @@
   ],
   "include": [
     "src/**/*.d.ts"
-  ],
-  "exclude": [
-    "src/test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*-specs.ts",
-    "src/**/*.avoid.ts",
-    "src/**/*.0.ts",
-    "src/**/*.1.ts",
-    "src/**/*.1b.ts",
-    "src/**/*.2.ts",
-    "src/**/*.3.ts",
-    "src/**/*.4.ts",
-    "src/**/*.5.ts",
-    "src/**/*.6.ts",
-    "src/**/*.7.ts",
-    "src/**/testing"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,9 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "useDefineForClassFields": false,
     "target": "ES2022",
     "module": "ES2022",
+    "useDefineForClassFields": false,
     "lib": [
       "ES2022",
       "dom"

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,14 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
Why
--
As a developer, I should be able to run tests

How
--
Update config
Add product-alerts tests

Note
--
Other tests fail due to their implementation of an unmocked service, I'm still investigating how best to resolve that issue. 
 Until resolved, it is not required that all tests pass prior to merging PRs.